### PR TITLE
Backport of fixes for Python 3.5 on Windows

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -164,7 +164,7 @@ double npy_spacing(double x);
     #ifndef NPY_HAVE_DECL_ISNAN
         #define npy_isnan(x) ((x) != (x))
     #else
-        #ifdef _MSC_VER
+        #if defined(_MSC_VER) && (_MSC_VER < 1900)
             #define npy_isnan(x) _isnan((x))
         #else
             #define npy_isnan(x) isnan(x)
@@ -195,7 +195,7 @@ double npy_spacing(double x);
     #ifndef NPY_HAVE_DECL_ISINF
         #define npy_isinf(x) (!npy_isfinite(x) && !npy_isnan(x))
     #else
-        #ifdef _MSC_VER
+        #if defined(_MSC_VER) && (_MSC_VER < 1900)
             #define npy_isinf(x) (!_finite((x)) && !_isnan((x)))
         #else
             #define npy_isinf(x) isinf((x))

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -171,6 +171,15 @@ def check_long_double_representation(cmd):
     cmd._check_compiler()
     body = LONG_DOUBLE_REPRESENTATION_SRC % {'type': 'long double'}
 
+    # Disable whole program optimization (the default on vs2015, with python 3.5+)
+    # which generates intermediary object files and prevents checking the
+    # float representation.
+    if sys.platform == "win32":
+        try:
+            cmd.compiler.compile_options.remove("/GL")
+        except ValueError:
+            pass
+
     # We need to use _compile because we need the object filename
     src, object = cmd._compile(body, None, None, 'c')
     try:

--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -6,9 +6,33 @@
 #include "numpy/npy_cpu.h"
 
 /* Disable broken MS math functions */
-#if defined(_MSC_VER) || defined(__MINGW32_VERSION)
+#if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(__MINGW32_VERSION)
+
 #undef HAVE_ATAN2
+#undef HAVE_ATAN2F
+#undef HAVE_ATAN2L
+
 #undef HAVE_HYPOT
+#undef HAVE_HYPOTF
+#undef HAVE_HYPOTL
+
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER == 1900)
+
+#undef HAVE_CASIN
+#undef HAVE_CASINF
+#undef HAVE_CASINL
+#undef HAVE_CASINH
+#undef HAVE_CASINHF
+#undef HAVE_CASINHL
+#undef HAVE_CATAN
+#undef HAVE_CATANF
+#undef HAVE_CATANL
+#undef HAVE_CATANH
+#undef HAVE_CATANHF
+#undef HAVE_CATANHL
+
 #endif
 
 /*

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -152,7 +152,7 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
     module_include_switch = '/I'
 
     def get_flags(self):
-        opt = ['/nologo', '/MD', '/nbs', '/Qlowercase', '/us']
+        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', '/assume:underscore']
         return opt
 
     def get_flags_free(self):


### PR DESCRIPTION
Re MRG: preparations for 1.9.3 release #6332
Tested on Windows with Python 3.5 and 2.7 (32 and 64 bit) using Visual Studio 2015 and 2008, respectively.
